### PR TITLE
requirements-deb: pin python-debian

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ pytest-random-order == 1.0.4
 pytest-socket == 0.5.1
 pytest-sugar == 0.9.5
 pytest-tldr == 0.2.4
+python-debian==0.1.44
 reuse == 1.0.0
 twine == 4.0.1
 wemake-python-styleguide == 0.16.1


### PR DESCRIPTION
to an older version till a fix regarding
'ABCMeta' object is not subscriptable on Python 3.8.10 is released to PyPi

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>